### PR TITLE
Update FritzBoxConnection.java

### DIFF
--- a/src/de/FBEditor/FritzBoxConnection.java
+++ b/src/de/FBEditor/FritzBoxConnection.java
@@ -154,7 +154,8 @@ public class FritzBoxConnection {
 				boxtypeString = m.group(1);
 				majorFirmwareVersion = m.group(2);
 				minorFirmwareVersion = m.group(3);
-				modFirmwareVersion = m.group(4).trim();
+//				modFirmwareVersion = m.group(4).trim(); // Fehler nicht vorhanden
+				modFirmwareVersion = ""; // erkennt sonst die Box 701/900 nicht
 			}
 
 		}


### PR DESCRIPTION
Erkennt sonst die Firmware der Boxen 701/900 usw. nicht
da es den Punkt modFirmwareVersion nicht gibt
